### PR TITLE
Slightly better storage

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,7 +6,6 @@ NOT FOR PRODUCTION USE.
 
 Things that are missing:
 
-* A half-decent persistence plan
 * Snapshotting/checkpointing and associated state transfer
 * Configuration change protocol
 * Rigged up to Jepsen

--- a/cmd/sim/main.go
+++ b/cmd/sim/main.go
@@ -107,7 +107,7 @@ func main() {
 	s2 := goraft.NewServer(cluster, sm2, ".", 1)
 	s3 := goraft.NewServer(cluster, sm3, ".", 2)
 
-	DEBUG := true
+	DEBUG := false
 	s1.Debug = DEBUG
 	s1.Start()
 	s2.Debug = DEBUG
@@ -115,10 +115,25 @@ func main() {
 	s3.Debug = DEBUG
 	s3.Start()
 
+outer:
+	for {
+		for _, s := range []*goraft.Server{s1, s2, s3} {
+			if s.IsLeader() {
+				break outer
+			}
+		}
+
+		fmt.Println("Waiting for a leader.")
+		time.Sleep(time.Second)
+	}
+
+	N_ENTRIES := 3_000
+
 	var randKey, randValue string
 	t := time.Now()
-	for i := 0; i < 1_000; i++ {
-		if i%100 == 0 && i > 0 {
+	total := time.Now()
+	for i := 0; i < N_ENTRIES; i++ {
+		if i%1000 == 0 && i > 0 {
 			fmt.Printf("%d entries inserted in %s.\n", i, time.Now().Sub(t))
 			t = time.Now()
 		}
@@ -147,6 +162,7 @@ func main() {
 
 		goraft.Assert("Quorum reached", s1.Entries() == s2.Entries() || s1.Entries() == s3.Entries() || s2.Entries() == s3.Entries(), true)
 	}
+	fmt.Printf("Total time: %s. Average insert/second: %s.\n", time.Now().Sub(total), time.Now().Sub(total)/time.Duration(N_ENTRIES))
 
 	var v []byte
 	var err error
@@ -161,6 +177,9 @@ func main() {
 		}
 	}
 
+	// Ooph, but need to wait for the other state machines to catch up.
+	time.Sleep(2 * time.Second)
+
 	for _, sm := range []*kvStateMachine{sm1, sm2, sm3} {
 		goraft.Assert("Each node state machine is up-to-date", string(v), sm.kv[randKey])
 		goraft.Assert("Each node state machine is up-to-date", randValue, sm.kv[randKey])
@@ -170,30 +189,3 @@ func main() {
 
 	fmt.Printf("%s = %s, expected: %s\n", randKey, string(v), randValue)
 }
-
-/*
-	  OLD
-
-	   _, err := s1.Apply(kvsmMessage_Set("a", "1"))
-	if err != nil {
-		panic(err)
-	}
-	goraft.Assert("s1.Entries() == s2.Entries()", s1.Entries() == s2.Entries(), true)
-	goraft.Assert("s1.Entries() == s3.Entries()", s1.Entries() == s3.Entries(), true)
-
-	_, err = s1.Apply(kvsmMessage_Set("b", "2"))
-	if err != nil {
-		panic(err)
-	}
-	goraft.Assert("s1.Entries() == s2.Entries()", s1.Entries() == s2.Entries(), true)
-	goraft.Assert("s1.Entries() == s3.Entries()", s1.Entries() == s3.Entries(), true)
-
-	v, err := s1.Apply(kvsmMessage_Get("a"))
-	if err != nil {
-		panic(err)
-	}
-	goraft.Assert("s1.Entries() == s2.Entries()", s1.Entries() == s2.Entries(), true)
-	goraft.Assert("s1.Entries() == s3.Entries()", s1.Entries() == s3.Entries(), true)
-
-
-*/

--- a/cmd/sim/main.go
+++ b/cmd/sim/main.go
@@ -86,15 +86,15 @@ func main() {
 
 	cluster := []goraft.ClusterMember{
 		{
-			Id:      "0",
+			Id:      1,
 			Address: "localhost:2020",
 		},
 		{
-			Id:      "1",
+			Id:      2,
 			Address: "localhost:2021",
 		},
 		{
-			Id:      "2",
+			Id:      3,
 			Address: "localhost:2022",
 		},
 	}
@@ -107,7 +107,7 @@ func main() {
 	s2 := goraft.NewServer(cluster, sm2, ".", 1)
 	s3 := goraft.NewServer(cluster, sm3, ".", 2)
 
-	DEBUG := false
+	DEBUG := true
 	s1.Debug = DEBUG
 	s1.Start()
 	s2.Debug = DEBUG
@@ -116,9 +116,11 @@ func main() {
 	s3.Start()
 
 	var randKey, randValue string
+	t := time.Now()
 	for i := 0; i < 1_000; i++ {
-		if i%100 == 0 {
-			fmt.Printf("%d entries inserted.\n", i)
+		if i%100 == 0 && i > 0 {
+			fmt.Printf("%d entries inserted in %s.\n", i, time.Now().Sub(t))
+			t = time.Now()
 		}
 		key := randomString()
 		value := randomString()

--- a/go.mod
+++ b/go.mod
@@ -2,4 +2,8 @@ module goraft
 
 go 1.19
 
-replace github.com/eatonphil/goraft => ../..//
+replace github.com/eatonphil/goraft => ../.. //
+
+require github.com/sasha-s/go-deadlock v0.3.1
+
+require github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 // indirect

--- a/go.sum
+++ b/go.sum
@@ -1,0 +1,4 @@
+github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5 h1:q2e307iGHPdTGp0hoxKjt1H5pDo6utceo3dQVK3I5XQ=
+github.com/petermattis/goid v0.0.0-20180202154549-b0b1615b78e5/go.mod h1:jvVRKCrJTQWu0XVbaOlby/2lO20uSCHEMzzplHXte1o=
+github.com/sasha-s/go-deadlock v0.3.1 h1:sqv7fDNShgjcaxkO0JNcOAlr8B9+cV5Ey/OB71efZx0=
+github.com/sasha-s/go-deadlock v0.3.1/go.mod h1:F73l+cr82YSh10GxyRI6qZiCgK64VaZjwesgfQ1/iLM=

--- a/raft.go
+++ b/raft.go
@@ -292,10 +292,9 @@ func (s *Server) persist(writeLogs bool, nNewLogs int) {
 	}
 	Server_assert(s, "Wrote full page", n, PAGE_SIZE)
 
-
 	if nNewLogs > 0 {
 
-		newLogOffset := max(len(s.log) - nNewLogs, 0)
+		newLogOffset := max(len(s.log)-nNewLogs, 0)
 
 		s.fd.Seek(int64(PAGE_SIZE+ENTRY_SIZE*newLogOffset), 0)
 
@@ -305,8 +304,8 @@ func (s *Server) persist(writeLogs bool, nNewLogs int) {
 			// Bytes 8 - 16:   Entry command length
 			// Bytes 16 - ENTRY_SIZE: Entry command
 
-			if len(s.log[i].Command) > ENTRY_SIZE - ENTRY_HEADER {
-				panic(fmt.Sprintf("Command is too large. Must be at most %d bytes.", ENTRY_SIZE - ENTRY_HEADER))
+			if len(s.log[i].Command) > ENTRY_SIZE-ENTRY_HEADER {
+				panic(fmt.Sprintf("Command is too large. Must be at most %d bytes.", ENTRY_SIZE-ENTRY_HEADER))
 			}
 
 			binary.LittleEndian.PutUint64(entryBytes[:8], s.log[i].Term)
@@ -347,7 +346,7 @@ func (s *Server) initialize() {
 func (s *Server) restore() {
 	s.mu.Lock()
 	defer s.mu.Unlock()
-	
+
 	if s.fd == nil {
 		var err error
 		s.fd, err = os.OpenFile(
@@ -397,7 +396,7 @@ func (s *Server) restore() {
 			// Bytes 16 - ENTRY_SIZE: Entry command
 			e.Term = binary.LittleEndian.Uint64(entryBytes[:8])
 			lenValue := binary.LittleEndian.Uint64(entryBytes[8:16])
-			e.Command = entryBytes[16:16 + lenValue]
+			e.Command = entryBytes[16 : 16+lenValue]
 			s.log[i] = e
 		}
 	}
@@ -558,11 +557,11 @@ func (s *Server) HandleAppendEntriesRequest(req AppendEntriesRequest, rsp *Appen
 
 	next := req.PrevLogIndex + 1
 	nNewLogs := 0
-	for i := next; i < next + uint64(len(req.Entries)); i++ {
-		e := req.Entries[i - next]
+	for i := next; i < next+uint64(len(req.Entries)); i++ {
+		e := req.Entries[i-next]
 		if i >= uint64(len(s.log)) || s.log[i].Term != e.Term {
 			// Either allocate space for the whole thing, or truncate when terms mismatch.
-			newLog := make([]Entry, next + uint64(len(req.Entries)))
+			newLog := make([]Entry, next+uint64(len(req.Entries)))
 			copy(newLog, s.log)
 			s.log = newLog
 		}
@@ -653,7 +652,7 @@ func (s *Server) appendEntries() {
 
 			// Keep latency down by only applying N at a time.
 			if len(entries) > 50 {
-			 	entries = entries[:50]
+				entries = entries[:50]
 			}
 
 			lenEntries := uint64(len(entries))
@@ -691,8 +690,8 @@ func (s *Server) appendEntries() {
 
 			if rsp.Success {
 				prev := s.cluster[i].nextIndex
-				s.cluster[i].nextIndex = max(req.PrevLogIndex + lenEntries + 1, 1)
-				s.cluster[i].matchIndex = s.cluster[i].nextIndex-1
+				s.cluster[i].nextIndex = max(req.PrevLogIndex+lenEntries+1, 1)
+				s.cluster[i].matchIndex = s.cluster[i].nextIndex - 1
 				s.debugf("Message accepted for %d. Prev Index: %d, Next Index: %d, Match Index: %d.", s.cluster[i].Id, prev, s.cluster[i].nextIndex, s.cluster[i].matchIndex)
 			} else {
 				s.cluster[i].nextIndex = max(s.cluster[i].nextIndex-1, 1)

--- a/raft.go
+++ b/raft.go
@@ -672,6 +672,10 @@ func (s *Server) appendEntries(heartbeat bool) {
 			}
 
 			entries = s.log[logBegin:]
+			// Keep latency down by only applying N at a time.
+			if len(entries) > 50 {
+				entries = entries[:50]
+			}
 
 			lenEntries := uint64(len(entries))
 			req := AppendEntriesRequest{

--- a/raft_test.go
+++ b/raft_test.go
@@ -1,0 +1,62 @@
+package goraft
+
+import (
+	"testing"
+	"bytes"
+)
+
+func Test_persist_restore(t *testing.T) {
+	s := NewServer(
+		[]ClusterMember{
+			{
+				Id: 1,
+				Address: ":3030",
+			},
+		},
+		nil,
+		".",
+		0,
+	)
+
+	// Sets up the file
+	s.restore()
+
+	log := []Entry{
+		{
+			Term: 23,
+			Command: []byte("Hey there"),
+		},
+		{
+			Term: 56,
+			Command: []byte("what's cooking"),
+		},
+		{
+			Term: 809,
+			Command: []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
+		},
+	}
+	s.log = log
+
+	s.persist(true, len(log))
+	s.restore()
+
+	if len(s.log) != len(log) {
+		t.Errorf("Expected log to be %d, is %d", len(log), len(s.log))
+	}
+
+	s.mu.Lock()
+	for i := range log {
+		if log[i].Term != s.log[i].Term {
+			t.Errorf("Expected log %d term to be %d, got %d.", i, log[i].Term, s.log[i].Term)
+		}
+
+		if len(log[i].Command) != len(s.log[i].Command) {
+			t.Errorf("Expected log %d command length to be %d, got %d.", i, len(log[i].Command), len(s.log[i].Command))
+		}
+
+		if !bytes.Equal(log[i].Command, s.log[i].Command) {
+			t.Errorf("Expected log %d command to be '%s', got '%s'.", i, string(log[i].Command), string(s.log[i].Command))
+		}
+	}
+	s.mu.Unlock()
+}

--- a/raft_test.go
+++ b/raft_test.go
@@ -1,15 +1,15 @@
 package goraft
 
 import (
-	"testing"
 	"bytes"
+	"testing"
 )
 
 func Test_persist_restore(t *testing.T) {
 	s := NewServer(
 		[]ClusterMember{
 			{
-				Id: 1,
+				Id:      1,
 				Address: ":3030",
 			},
 		},
@@ -23,15 +23,15 @@ func Test_persist_restore(t *testing.T) {
 
 	log := []Entry{
 		{
-			Term: 23,
+			Term:    23,
 			Command: []byte("Hey there"),
 		},
 		{
-			Term: 56,
+			Term:    56,
 			Command: []byte("what's cooking"),
 		},
 		{
-			Term: 809,
+			Term:    809,
 			Command: []byte("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"),
 		},
 	}


### PR DESCRIPTION
Before this every write would write all logs. This works great for single digit number of logs but not past that.

Instead the new scheme only writes logs that it needs to write, including ones that must be overwritten.

It isn't particularly _fast_ but it at least now latency doesn't grow with the number of log entries.

This also ended up fixing small bugs in heartbeating/append-entries/nextIndex.